### PR TITLE
Replace bcrypt-as-promised with bcrypt

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/gschool/galvanize-bookshelf#readme",
   "dependencies": {
-    "bcrypt-as-promised": "^1.1.0",
+    "bcrypt": "1.0.2",
     "body-parser": "^1.15.2",
     "boom": "^3.2.2",
     "cookie-parser": "^1.4.3",


### PR DESCRIPTION
bcrypt now ships with native promise support which means that
bcrypt-as-promised is so longer necessary.